### PR TITLE
Add Jest unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ export default {
   testEnvironment: 'node',
   collectCoverage: true,
   coverageDirectory: 'coverage',
+  coveragePathIgnorePatterns: ['src/server.js'],
   coverageThreshold: {
     global: {
       branches: 90,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+export default {
+  testEnvironment: 'node',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node --watch src/server.js"
+    "dev": "node --watch src/server.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "keywords": ["notifications", "firebase", "rabbitmq", "fcm"],
   "author": "Grupo 2",
@@ -18,6 +19,7 @@
     "firebase-admin": "^13.3.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "jest": "^29.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:coverage": "npm test -- --coverage"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:coverage": "npm run test -- --coverage"
   },
   "keywords": ["notifications", "firebase", "rabbitmq", "fcm"],
   "author": "Grupo 2",
@@ -20,7 +20,8 @@
     "firebase-admin": "^13.3.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1",
-    "jest": "^29.7.0"
+    "cross-env": "^7.0.3",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:coverage": "npm test -- --coverage"
   },
   "keywords": ["notifications", "firebase", "rabbitmq", "fcm"],
   "author": "Grupo 2",

--- a/src/__tests__/notification-service.test.js
+++ b/src/__tests__/notification-service.test.js
@@ -1,0 +1,72 @@
+import {
+  convertToStringValues,
+  sendNotification,
+  sendBulkNotifications,
+  processNotification,
+  initializeFirebase
+} from '../notification-service.js';
+
+import admin from 'firebase-admin';
+
+jest.mock('firebase-admin', () => ({
+  credential: { cert: jest.fn(() => 'cert') },
+  initializeApp: jest.fn(),
+  messaging: jest.fn(() => ({ send: jest.fn(async () => 'msg-id') }))
+}));
+
+describe('convertToStringValues', () => {
+  test('converts values to strings', () => {
+    const data = { num: 1, obj: { a: 2 }, str: 'ok' };
+    expect(convertToStringValues(data)).toEqual({ num: '1', obj: JSON.stringify({ a: 2 }), str: 'ok' });
+  });
+});
+
+describe('sendNotification', () => {
+  beforeAll(() => {
+    process.env.FIREBASE_PROJECT_ID = 'id';
+    process.env.FIREBASE_PRIVATE_KEY = 'key';
+    process.env.FIREBASE_CLIENT_EMAIL = 'test@test.com';
+    initializeFirebase();
+  });
+
+  test('fails when firebase not initialized', async () => {
+    jest.resetModules();
+    const mod = await import('../notification-service.js');
+    const result = await mod.sendNotification('t', { title: 'x' });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Firebase not initialized');
+  });
+
+  test('sends notification when firebase initialized', async () => {
+    const result = await sendNotification('token', { title: 't' });
+    expect(result).toEqual({ success: true, messageId: 'msg-id' });
+    expect(admin.messaging().send).toHaveBeenCalled();
+  });
+});
+
+describe('sendBulkNotifications', () => {
+  test('aggregates success and failures', async () => {
+    const spy = jest.spyOn(admin.messaging(), 'send');
+    spy.mockResolvedValueOnce('1');
+    spy.mockRejectedValueOnce(new Error('fail'));
+    const result = await sendBulkNotifications(['a', 'b'], { title: 't' });
+    expect(result).toEqual({ success: true, successCount: 1, failureCount: 1 });
+  });
+});
+
+describe('processNotification', () => {
+  test('processes single notification', async () => {
+    const singleSpy = jest.spyOn(admin.messaging(), 'send').mockResolvedValue('1');
+    const result = await processNotification({
+      to: 'token',
+      notification: { title: 't' },
+      data: { type: 'single' }
+    });
+    expect(result.success).toBe(true);
+    expect(singleSpy).toHaveBeenCalled();
+  });
+
+  test('throws on invalid task', async () => {
+    await expect(processNotification({})).rejects.toThrow('Incomplete notification data');
+  });
+});

--- a/src/__tests__/rabbitmq.test.js
+++ b/src/__tests__/rabbitmq.test.js
@@ -1,0 +1,21 @@
+import { connectRabbitMQ } from '../notification-service.js';
+import amqp from 'amqplib';
+
+jest.mock('amqplib', () => ({ connect: jest.fn() }));
+
+describe('connectRabbitMQ', () => {
+  test('retries before succeeding', async () => {
+    amqp.connect
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue('conn');
+
+    const conn = await connectRabbitMQ(0, 2);
+    expect(conn).toBe('conn');
+    expect(amqp.connect).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws after max retries', async () => {
+    amqp.connect.mockRejectedValue(new Error('fail'));
+    await expect(connectRabbitMQ(0, 1)).rejects.toThrow('fail');
+  });
+});

--- a/src/__tests__/service.test.js
+++ b/src/__tests__/service.test.js
@@ -1,0 +1,75 @@
+import * as svc from '../notification-service.js';
+
+const connectSpy = jest.spyOn(svc, 'connectRabbitMQ');
+const processSpy = jest.spyOn(svc, 'processNotification');
+
+const makeChannel = () => ({
+  assertExchange: jest.fn(),
+  assertQueue: jest.fn(),
+  bindQueue: jest.fn(),
+  consume: jest.fn(),
+  ack: jest.fn(),
+  sendToQueue: jest.fn(),
+  publish: jest.fn(),
+  close: jest.fn(),
+});
+
+const makeConnection = (channel) => ({
+  createChannel: jest.fn().mockResolvedValue(channel),
+  close: jest.fn(),
+});
+
+describe('startNotificationService', () => {
+  afterEach(() => jest.clearAllMocks());
+  test('consumes and processes messages', async () => {
+    const channel = makeChannel();
+    const connection = makeConnection(channel);
+    connectSpy.mockResolvedValue(connection);
+    processSpy.mockResolvedValue({ success: true });
+
+    const promise = svc.startNotificationService();
+    const result = await promise;
+    expect(result).toEqual({ connection, channel });
+
+    // simulate consuming a message
+    const msg = { content: Buffer.from('{}'), properties: { headers: {} } };
+    const consumeCb = channel.consume.mock.calls[0][1];
+    await consumeCb(msg);
+
+    expect(processSpy).toHaveBeenCalled();
+    expect(channel.ack).toHaveBeenCalledWith(msg);
+  });
+
+  test('requeues message on failure', async () => {
+    const channel = makeChannel();
+    const connection = makeConnection(channel);
+    connectSpy.mockResolvedValue(connection);
+    processSpy.mockRejectedValue(new Error('fail'));
+
+    const promise = svc.startNotificationService();
+    await promise;
+    const msg = { content: Buffer.from('{}'), properties: { headers: { 'x-retries': 0 } } };
+    const consumeCb = channel.consume.mock.calls[0][1];
+    await consumeCb(msg);
+
+    expect(channel.sendToQueue).toHaveBeenCalled();
+    expect(channel.publish).not.toHaveBeenCalled();
+    expect(channel.ack).toHaveBeenCalledWith(msg);
+  });
+
+  test('moves to DLQ after max retries', async () => {
+    const channel = makeChannel();
+    const connection = makeConnection(channel);
+    connectSpy.mockResolvedValue(connection);
+    processSpy.mockRejectedValue(new Error('fail'));
+
+    const promise = svc.startNotificationService();
+    await promise;
+    const msg = { content: Buffer.from('{}'), properties: { headers: { 'x-retries': 5 } } };
+    const consumeCb = channel.consume.mock.calls[0][1];
+    await consumeCb(msg);
+
+    expect(channel.publish).toHaveBeenCalled();
+    expect(channel.ack).toHaveBeenCalledWith(msg);
+  });
+});

--- a/src/notification-service.js
+++ b/src/notification-service.js
@@ -236,4 +236,12 @@ const startNotificationService = async () => {
   }
 };
 
-export { initializeFirebase, startNotificationService };
+export {
+  initializeFirebase,
+  startNotificationService,
+  sendNotification,
+  sendBulkNotifications,
+  convertToStringValues,
+  processNotification,
+  connectRabbitMQ,
+};


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency and create test script
- export internal helpers from notification-service
- add Jest unit tests for notification functions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489e700f50832994f878ca27828a2b